### PR TITLE
Feature/configuration dsl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,9 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    testImplementation 'io.kotest:kotest-runner-junit5:4.6.3'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'io.kotest:kotest-runner-junit5:5.0.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31'
     implementation 'org.jetbrains.kotlin:kotlin-reflect:1.5.31'
 }

--- a/src/main/kotlin/micro-template.kt
+++ b/src/main/kotlin/micro-template.kt
@@ -175,6 +175,14 @@ private class Format(val separator: String) {
  */
 class TypedMicroTemplate<T : Any>(val template: MicroTemplate, contextType: KClass<T>) :
     Template<T> {
+    init {
+        // needed because of https://youtrack.jetbrains.com/issue/KT-18408
+        require(contextType.visibility != KVisibility.PRIVATE) {
+            "The context type ${contextType.qualifiedName} must be public or internal " +
+                    "in order to access its properties from the template"
+        }
+    }
+
     private val publicProperties =
         contextType.memberProperties.filter { it.visibility == KVisibility.PUBLIC }
 

--- a/src/test/kotlin/FactoriesSpec.kt
+++ b/src/test/kotlin/FactoriesSpec.kt
@@ -4,6 +4,7 @@ package io.github.polarene
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.beOfType
 
 /**
@@ -11,12 +12,18 @@ import io.kotest.matchers.types.beOfType
  * @author mmirk
  */
 class FactoriesSpec : StringSpec({
-    val definition = "Hello, {thing}!"
-
-    "should create a template accepting a Context instance" {
+    "should create a template accepting a Context" {
         val hello: Template<Context> = templateOf(definition)
 
         hello should beOfType<MicroTemplate>()
+    }
+
+    "should create a template accepting a Context from the given configuration" {
+        val hello = templateOf(definition) {
+            globalDefault = "N/A"
+        }
+
+        hello(emptyMap()) shouldBe "Hello, N/A!"
     }
 
     "should create a template accepting an instance of the specified type" {
@@ -24,6 +31,16 @@ class FactoriesSpec : StringSpec({
 
         hello should beOfType<TypedMicroTemplate<Box>>()
     }
+
+    "should create a template accepting an instance of the specified type from the given configuration" {
+        val hello = templateOf<Box>(definition) {
+            globalDefault = "N/A"
+        }
+
+        hello(Box(null)) shouldBe "Hello, N/A!"
+    }
 })
 
-class Box(val thing: String)
+private const val definition = "Hello, {thing}!"
+
+class Box(val thing: String?)

--- a/src/test/kotlin/MicroTemplateSpec.kt
+++ b/src/test/kotlin/MicroTemplateSpec.kt
@@ -67,7 +67,8 @@ class MicroTemplateSpec : StringSpec({
 
     "should replace any missing token with a global default value" {
         val context = emptyMap<String, Any>()
-        val greeting = MicroTemplate("Hello, {title}{name}!", globalDefault = "-")
+        val config = Configuration(globalDefault = "-")
+        val greeting = MicroTemplate("Hello, {title}{name}!", config)
 
         greeting(context) shouldBe "Hello, --!"
     }
@@ -132,6 +133,14 @@ class MicroTemplateSpec : StringSpec({
         val bingo = MicroTemplate("Winning numbers: {extraction}")
 
         bingo(context) shouldBe "Winning numbers: 5,22,17,80,3"
+    }
+
+    "should render an iterable with the given separator" {
+        val context = mapOf("fruits" to listOf("apple", "banana", "grape"))
+        val config = Configuration(separator = " | ")
+        val fruits = MicroTemplate("Fruit list: {fruits}", config)
+
+        fruits(context) shouldBe "Fruit list: apple | banana | grape"
     }
 })
 

--- a/src/test/kotlin/TypedMicroTemplateSpec.kt
+++ b/src/test/kotlin/TypedMicroTemplateSpec.kt
@@ -33,6 +33,13 @@ class TypedMicroTemplateSpec : StringSpec({
         typedHello(context) shouldBe "Hello, Smith!"
     }
 
+    "should accept an internal class with public properties" {
+        val context = ConfidentialCard(name = "Smith")
+        val typedHello = TypedMicroTemplate(hello, ConfidentialCard::class)
+
+        typedHello(context) shouldBe "Hello, Smith!"
+    }
+
     "should accept an interface with properties" {
         val context = User("Smith")
         val typedHello = TypedMicroTemplate(hello, Id::class)
@@ -68,20 +75,28 @@ class TypedMicroTemplateErrorSpec : StringSpec({
             TypedMicroTemplate(hello, NoMatchingProperties::class)
         }
     }
+
+    "should reject a private class with public properties" {
+        shouldThrow<IllegalArgumentException> {
+            TypedMicroTemplate(hello, Private::class)
+        }
+    }
 })
 
 // the reference template to be wrapped
-val hello = MicroTemplate("Hello, {title}{name}!")
+private val hello = MicroTemplate("Hello, {title}{name}!")
 
 /* --- simple classes --- */
 class BusinessCard(val name: String, val title: String)
 class BusinessCardNil(val name: String, val title: String? = null)
 data class BusinessCardDC(val name: String, val title: String? = null)
+internal class ConfidentialCard(val name: String)
 
 /* --- interfaces and parents --- */
 interface Id {
     val name: String
 }
+
 class User(override val name: String) : Id
 abstract class Title(val title: String)
 class TitledUser(val name: String, title: String) : Title(title)
@@ -90,3 +105,6 @@ class TitledUser(val name: String, title: String) : Title(title)
 class Empty
 class NoPublicProperties(private val name: String)
 class NoMatchingProperties(val id: Long, val updated: Boolean)
+
+/* --- inaccessible --- */
+private class Private(val name: String)


### PR DESCRIPTION
Introduces a builder lambda for configuring a template when using factory functions. All the setup properties and defaults are now in the `Configuration` class.

Also, a bug was discovered: when invoking a typed template accepting a private class it would throw a runtime exception with a misleading message. The fix introduces an init check that fails earlier with an informative message.

**BREAKING CHANGE**: MicroTemplate signature has changed to accept a Configuration parameter.